### PR TITLE
Updated guaranteed samples for 1.0.0 changes

### DIFF
--- a/samples/guaranteed_subscriber.py
+++ b/samples/guaranteed_subscriber.py
@@ -88,7 +88,7 @@ except PubSubPlusClientError as exception:
 finally:
     if persistent_receiver.is_running():
       print('\nTerminating receiver')
-      persistent_receiver.terminate_now()
+      persistent_receiver.terminate(grace_period = 0)
     print('\nDisconnecting Messaging Service')
     messaging_service.disconnect()
 


### PR DESCRIPTION
Renamed delivery listener to message publish receipt listener.
Updated receiver terminate_now to use replacement terminate.