### PR TITLE
SOL-81976: Fixed incorrect JSON property string in solbroker_properties

### DIFF
--- a/howtos/solbroker_properties.json
+++ b/howtos/solbroker_properties.json
@@ -4,8 +4,8 @@
     "solace.messaging.transport.host.secured": "tcps://localhost:55443",
     "solace.messaging.transport.host.compressed": "tcp://localhost:55003",
     "solace.messaging.service.vpn-name": "default",
-    "solace.messaging.authentication.scheme.basic.username": "default",
-    "solace.messaging.authentication.scheme.basic.password": "default"
+    "solace.messaging.authentication.basic.username": "default",
+    "solace.messaging.authentication.basic.password": "default"
   },
   "semp": {
     "semp.hostname": "https://localhost:1943",


### PR DESCRIPTION
I manually verified that the change works by running
```
 PYTHONPATH=. SOLACE_VPN=default SOLACE_USERNAME=default python howtos/pubsub/how_to_use_local_transactions.py 
```
against a 1.4.0 load of the Python API.